### PR TITLE
.helm-docs-templates/README.md.gotmpl: remove helm-docs.versionFooter…

### DIFF
--- a/.helm-docs-templates/README.md.gotmpl
+++ b/.helm-docs-templates/README.md.gotmpl
@@ -134,6 +134,4 @@ Open an [issue](https://github.com/johanneskastl/helm-charts/issues/).
 {{ template "custom.changelog" . }}
 
 {{ template "custom.support" . }}
-
-{{ template "helm-docs.versionFooter" . }}
 {{ "" }}


### PR DESCRIPTION
… that was only working in k8s@home patched version of helm-docs