### PR TITLE
patch: Newer tailscale versions want to patch the secret, instead of update

### DIFF
--- a/charts/tailscale/README.md
+++ b/charts/tailscale/README.md
@@ -19,7 +19,7 @@ Store the API-key in a secret in the namespace. By default, this chart requires 
 ```yaml
 apiVersion: v1
 stringData:
-  TS_AUTH_KEY: tskey-auth-...
+  authkey: tskey-auth-...
 kind: Secret
 metadata:
   name: tailscale-auth

--- a/charts/tailscale/templates/rbac.yaml
+++ b/charts/tailscale/templates/rbac.yaml
@@ -18,6 +18,7 @@ rules:
   verbs:
   - get
   - update
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
Also fix small issue in the docs, where the key should actually be authkey, instead of TS_AUTH_KEY